### PR TITLE
Let the user use the QR code instead of giving Duo their phone number

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install from PyPI:
 pip install --user duolibre
 ```
 
-Run Duolibre against the activation URL that was sent to your phone via SMS:
+Run Duolibre against the activation URL that was sent to your phone via SMS, or the URL of the QR code displayed on the web interface:
 
 ```
 duolibre https://m-XXXXXXXX.duosecurity.com/android/XXXXXXXXXXXXXXXXXXXX


### PR DESCRIPTION
This pull request adds functionality for transforming a QR code url into the activation URL (from https://github.com/WillForan/duo-hotp ) so that the user doesn't have to deal with SMS or email.