### PR TITLE
Fix QR code URLs for Dec 2025

### DIFF
--- a/duolibre/duolibre.py
+++ b/duolibre/duolibre.py
@@ -10,27 +10,9 @@ import requests
 from urllib import parse
 from urllib.parse import urlparse
 
-# this function is from https://github.com/WillForan/duo-hotp
-def qr_url_to_activation_url(qr_url):
-    "Create request URL"
-    # get ?value=XXX
-    data = parse.unquote(qr_url.split("?value=")[1])
-    # first half of value is the activation code
-    code = data.split("-")[0].replace("duo://", "")
-    # second half of value is the hostname in base64
-    hostb64 = data.split("-")[1]
-    # Same as "api-e4c9863e.duosecurity.com"
-    host = base64.b64decode(hostb64 + "=" * (-len(hostb64) % 4))
-    # this api is not publicly known
-    activation_url = "https://{host}/push/v2/activation/{code}".format(
-        host=host.decode("utf-8"), code=code
-    )
-    print(activation_url)
-    return activation_url
-
 def get_secret(activation_uri):
     if "frame/qr" in activation_uri:
-        activation_uri = qr_url_to_activation_url(activation_uri)
+        activation_uri = parse.unquote(activation_uri.split("?value=")[1])
     parsed = urlparse(activation_uri)
     subdomain = parsed.netloc.split(".")[0]
     host_id = subdomain.split("-")[-1]


### PR DESCRIPTION
Duo updated their QR code URLs to trivially embed the activation URL for the QR code; this breaks the previous `qr_url_to_activation_url`, so I replaced it with an inline call.

I have tested this and verified that it works.